### PR TITLE
fix: Fixed Failed to load class "org.slf4j.impl.StaticLoggerBinder".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
         <version.junit>4.13.2</version.junit>
+        <version.slf4j>2.0.7</version.slf4j>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <exec.mainClass>com.github.kwart.kerberos.KerberosServer</exec.mainClass>
@@ -98,12 +99,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>${version.slf4j}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>${version.slf4j}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,13 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>


### PR DESCRIPTION
Fixed the below message when starting kerberos server and logger levels that not was working:

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.